### PR TITLE
Adição de filtro de usuários por nome

### DIFF
--- a/rest-client/membership/users.rest
+++ b/rest-client/membership/users.rest
@@ -3,9 +3,8 @@
 
 ### List users
 GET {{URL}}
-?pageSize=2
-&isActive=true
-&nextCursor=qtbejiqzbsjm6dmpjfetskse
+?pageSize=10
+&nextCursor=z35xjfqsxrprkwo9eriqz9s6
 
 ### Create user
 POST {{URL}}

--- a/src/core/membership/domain/types/users-listing-params.ts
+++ b/src/core/membership/domain/types/users-listing-params.ts
@@ -1,4 +1,8 @@
+import { Text } from '@/core/global/domain/structures'
 import { CursorPaginationParams } from '@/core/global/domain/types'
 import { ListingParams } from '@/core/global/domain/types/listing-params'
 
-export type UsersListingParams = ListingParams & CursorPaginationParams
+export type UsersListingParams = {
+  name?: Text
+} & ListingParams &
+  CursorPaginationParams

--- a/src/core/membership/use-cases/list-users-use-case.ts
+++ b/src/core/membership/use-cases/list-users-use-case.ts
@@ -1,10 +1,11 @@
 import { UsersRepository } from '@/core/global/interfaces'
 import { CursorPaginationDto } from '@/core/global/domain/structures/dtos'
-import { Id, Logical } from '@/core/global/domain/structures'
+import { Id, Logical, Text } from '@/core/global/domain/structures'
 import { PlusInteger } from '@/core/global/domain/structures'
 import { UserDto } from '../domain/entities/dtos'
 
 type Request = {
+  name?: string
   nextCursor?: string
   previousCursor?: string
   pageSize: number
@@ -22,6 +23,7 @@ export class ListUsersUseCase {
         : undefined,
       pageSize: PlusInteger.create(params.pageSize),
       isActive: Logical.create(params.isActive),
+      name: params.name ? Text.create(params.name) : undefined,
     })
 
     return pagination.map((user) => user.dto).dto

--- a/src/core/membership/use-cases/tests/list-users-use-case.test.ts
+++ b/src/core/membership/use-cases/tests/list-users-use-case.test.ts
@@ -29,14 +29,17 @@ describe('Create User Use Case', () => {
   })
 
   it('should find many users with pagination without cursors', async () => {
+    const user = UsersFaker.fake()
     await useCase.execute({
+      name: user.name.value,
       pageSize: 10,
       isActive: false,
     })
 
     expect(repository.findMany).toHaveBeenCalledWith({
-      pageSize: PlusInteger.create(10),
+      name: user.name,
       isActive: Logical.createAsFalse(),
+      pageSize: PlusInteger.create(10),
       nextCursor: undefined,
       previousCursor: undefined,
     })

--- a/src/core/telemetry/use-cases/index.ts
+++ b/src/core/telemetry/use-cases/index.ts
@@ -3,4 +3,3 @@ export { EditParameterUseCase } from './edit-parameter-use-case'
 export { DeactivateParameterUseCase } from './deactivate-parameter-use-case'
 export { ActivateParameterUseCase } from './activate-parameter-use-case'
 export { ListParametersUseCase } from './list-parameters-use-case'
-export {ListParametersUseCase} from "./list-parameters-use-case"

--- a/src/infra/database/prisma/repositories/prisma-parameters-repository.ts
+++ b/src/infra/database/prisma/repositories/prisma-parameters-repository.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common'
 
 import type { ParametersRepository } from '@/core/global/interfaces'
 import { CursorPagination, Id } from '@/core/global/domain/structures'
-import { Parameter } from '@/core/telemetry/entities/parameter'
 import { PrismaParameterMapper } from '@/infra/database/prisma/mappers'
 import { ParametersListParams } from '@/core/global/types'
 import { PrismaRepository } from './prisma-repository'
@@ -71,7 +70,6 @@ export class PrismaParametersRepository
 
     const newNextCursor = this.getNewNextCursor(parameters, hasNextPage)
     const newPrevCursor = this.getNewPreviousCursor(parameters)
-    
 
     return CursorPagination.create({
       items: parameters.map(PrismaParameterMapper.toEntity),

--- a/src/infra/database/prisma/repositories/prisma-users-repository.ts
+++ b/src/infra/database/prisma/repositories/prisma-users-repository.ts
@@ -45,6 +45,7 @@ export class PrismaUsersRepository extends PrismaRepository implements UsersRepo
   }
 
   async findMany({
+    name,
     nextCursor,
     previousCursor,
     pageSize,
@@ -57,7 +58,7 @@ export class PrismaUsersRepository extends PrismaRepository implements UsersRepo
     if (nextCursor) {
       users = await this.prisma.user.findMany({
         ...this.getNextCursorPaginationParams(nextCursor, pageSize),
-        where: { isActive: isActive?.isTrue },
+        where: { isActive: isActive?.isTrue, name: { contains: name?.value } },
       })
       const result = this.getNextCursorPaginationResult(users, pageSize)
       users = result.items
@@ -66,7 +67,7 @@ export class PrismaUsersRepository extends PrismaRepository implements UsersRepo
     } else if (previousCursor) {
       users = await this.prisma.user.findMany({
         ...this.getPreviousCursorPaginationParams(previousCursor, pageSize),
-        where: { isActive: isActive?.isTrue },
+        where: { isActive: isActive?.isTrue, name: { contains: name?.value } },
       })
       const result = this.getPreviousCursorPaginationResult(users, pageSize)
       users = result.items
@@ -75,7 +76,7 @@ export class PrismaUsersRepository extends PrismaRepository implements UsersRepo
     } else {
       users = await this.prisma.user.findMany({
         ...this.getInitialPaginationParams(pageSize),
-        where: { isActive: isActive?.isTrue },
+        where: { isActive: isActive?.isTrue, name: { contains: name?.value } },
       })
       const result = this.getInitialPaginationResult(users, pageSize)
       users = result.items

--- a/src/infra/validation/schemas/zod/membership/users-listing-schema.ts
+++ b/src/infra/validation/schemas/zod/membership/users-listing-schema.ts
@@ -3,6 +3,7 @@ import z from 'zod'
 import { booleanSchema, plusIntegerSchema, stringSchema } from '../global'
 
 export const cursorListingSchema = z.object({
+  name: stringSchema.optional(),
   isActive: booleanSchema.optional().default(true),
   nextCursor: stringSchema.optional(),
   previousCursor: stringSchema.optional(),


### PR DESCRIPTION
## 🎯 Objetivo
Este PR introduz um novo recurso de filtragem na listagem de usuários. O objetivo é permitir que os usuários do sistema possam buscar por outros usuários utilizando um campo de nome, que agora se tornou opcional. Isso melhora a usabilidade da funcionalidade de busca e otimiza o fluxo de trabalho.

---

## 📋 Changelog
- Adicionado um filtro para o campo de nome, que agora é opcional.
- Atualizada a listagem de usuários para incluir o novo filtro.